### PR TITLE
Check hide-mode-line--old-format before setting mode-line-format.

### DIFF
--- a/hide-mode-line.el
+++ b/hide-mode-line.el
@@ -38,13 +38,17 @@
   :init-value nil
   :global nil
   (if hide-mode-line-mode
-      (progn
+      ;; Do not overwrite original mode line
+      (unless hide-mode-line--old-format
         (add-hook 'after-change-major-mode-hook #'hide-mode-line-reset nil t)
-        (setq hide-mode-line--old-format mode-line-format
-              mode-line-format hide-mode-line-format))
-    (remove-hook 'after-change-major-mode-hook #'hide-mode-line-reset t)
-    (setq mode-line-format hide-mode-line--old-format
-          hide-mode-line--old-format nil))
+        (setq-local hide-mode-line--old-format mode-line-format)
+        (setq mode-line-format hide-mode-line-format))
+    ;; else
+    ;; check old-format to prevent setting mode-line-format to nil
+    (when hide-mode-line--old-format
+      (remove-hook 'after-change-major-mode-hook #'hide-mode-line-reset t)
+      (setq mode-line-format hide-mode-line--old-format)
+      (setq-local hide-mode-line--old-format nil)))
   (force-mode-line-update))
 
 ;; Ensure major-mode or theme changes don't overwrite these variables
@@ -76,11 +80,6 @@ cycled to fix this."
 Unless in `fundamental-mode' or `hide-mode-line-excluded-modes'."
   (unless (memq major-mode hide-mode-line-excluded-modes)
     (hide-mode-line-mode +1)))
-
-;;;###autoload
-(defun turn-off-hide-mode-line-mode ()
-  "Turn off `hide-mode-line-mode'."
-  (hide-mode-line-mode -1))
 
 (provide 'hide-mode-line)
 ;;; hide-mode-line.el ends here


### PR DESCRIPTION
This fix #4 by checking if `hide-mode-line--old-format` has a value before enable mode. 
Checking for a value prevents overwriting its value the second time the mode is enable in the buffer, since `mode-line-format` holds the value of `hide-mode-line-format` and that's where the value was getting lost