### PR TITLE
Hide mode line face

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ Or replace the mode-line in specific windows:
 (setq-local hide-mode-line-format '("%b"))
 (hide-mode-line-mode +1)
 ```
+Also can change the face of the `mode-line` setting `hide-mode-line-face` with a
+face.
+
+```emacs-lsip
+(setq hide-mode-line-face 'mode-line-minor-mode-face)
+```
+
+Or with the list of attributes ([see Manual][attributes-doc]) that are passed to [`face-remap-add-relative`][remap-doc]
+
+```emacs-lisp
+(setq hide-mode-line-face (list :box nil :background "yellow" :height 0.25))
+```
+Or
+```emacs-lisp
+(setq hide-mode-line-face '(:box nil :background "blue" :height 0.1))
+```
 
 
 [doom]: https://github.com/hlissner/doom-emacs
+[attributes-doc]: https://www.gnu.org/software/emacs/manual/html_node/elisp/Face-Attributes.html
+[remap-doc]: https://www.gnu.org/software/emacs/manual/html_node/elisp/Face-Remapping.html

--- a/hide-mode-line.el
+++ b/hide-mode-line.el
@@ -22,17 +22,31 @@
 ;;
 ;;; Code:
 
-(defvar hide-mode-line-format nil
-  "The modeline format to use when `hide-mode-line-mode' is active.")
+(defcustom hide-mode-line-format ""
+  "The modeline format to use when `hide-mode-line-mode' is active."
+  :type 'string
+  :group 'hide-mode-line)
 
-(defvar hide-mode-line-face 'mode-line
-  "Remap to this face when `hide-mode-line-mode' is active.")
+(defun hide-mode-line--guess-face ()
+  "Set default face to hide mode-line."
+  (let ((background (face-background 'default))
+        (foreground (face-foreground 'default)))
+     (list :box nil :foreground foreground
+           :background background :height 0.5)))
+
+(defcustom hide-mode-line-face
+  (hide-mode-line--guess-face)
+  "Remap to this face when `hide-mode-line-mode' is active."
+  :type 'list
+  :group 'hide-mode-line)
 
 (defvar-local hide-mode-line--cookies nil
   "Storage for cookies when remaping mode-line and mode-line-inactive faces.")
 
-(defvar hide-mode-line-excluded-modes '(fundamental-mode)
-  "List of major modes where `global-hide-mode-line-mode' won't affect.")
+(defcustom hide-mode-line-excluded-modes '(fundamental-mode)
+  "List of major modes where `global-hide-mode-line-mode' won't affect."
+  :type 'list
+  :group 'hide-mode-line)
 
 (defvar-local hide-mode-line--old-format nil
   "Storage for the old `mode-line-format', so it can be restored when

--- a/hide-mode-line.el
+++ b/hide-mode-line.el
@@ -38,13 +38,17 @@
   :init-value nil
   :global nil
   (if hide-mode-line-mode
-      (progn
+      ;; Do not overwrite original mode line
+      (unless hide-mode-line--old-format
         (add-hook 'after-change-major-mode-hook #'hide-mode-line-reset nil t)
-        (setq hide-mode-line--old-format mode-line-format
-              mode-line-format hide-mode-line-format))
-    (remove-hook 'after-change-major-mode-hook #'hide-mode-line-reset t)
-    (setq mode-line-format hide-mode-line--old-format
-          hide-mode-line--old-format nil))
+        (setq-local hide-mode-line--old-format mode-line-format)
+        (setq mode-line-format hide-mode-line-format))
+    ;; else
+    ;; check old-format to prevent setting mode-line-format to nil
+    (when hide-mode-line--old-format
+      (remove-hook 'after-change-major-mode-hook #'hide-mode-line-reset t)
+      (setq mode-line-format hide-mode-line--old-format)
+      (setq-local hide-mode-line--old-format nil)))
   (force-mode-line-update))
 
 ;; Ensure major-mode or theme changes don't overwrite these variables
@@ -76,11 +80,6 @@ cycled to fix this."
 Unless in `fundamental-mode' or `hide-mode-line-excluded-modes'."
   (unless (memq major-mode hide-mode-line-excluded-modes)
     (hide-mode-line-mode +1)))
-
-;;;###autoload
-(defun turn-off-hide-mode-line-mode ()
-  "Turn off `hide-mode-line-mode'."
-  (hide-mode-line-mode -1))
 
 (provide 'hide-mode-line)
 ;;; hide-mode-line.el ends here

--- a/hide-mode-line.el
+++ b/hide-mode-line.el
@@ -25,6 +25,12 @@
 (defvar hide-mode-line-format nil
   "The modeline format to use when `hide-mode-line-mode' is active.")
 
+(defvar hide-mode-line-face 'mode-line
+  "Remap to this face when `hide-mode-line-mode' is active.")
+
+(defvar-local hide-mode-line--cookies nil
+  "Storage for cookies when remaping mode-line and mode-line-inactive faces.")
+
 (defvar hide-mode-line-excluded-modes '(fundamental-mode)
   "List of major modes where `global-hide-mode-line-mode' won't affect.")
 
@@ -42,12 +48,18 @@
       (unless hide-mode-line--old-format
         (add-hook 'after-change-major-mode-hook #'hide-mode-line-reset nil t)
         (setq-local hide-mode-line--old-format mode-line-format)
+        (setq-local hide-mode-line--cookies
+                    (mapcar (lambda (face)
+                              (face-remap-add-relative face
+                                                       hide-mode-line-face))
+                              '(mode-line mode-line-inactive)))
         (setq mode-line-format hide-mode-line-format))
     ;; else
     ;; check old-format to prevent setting mode-line-format to nil
     (when hide-mode-line--old-format
       (remove-hook 'after-change-major-mode-hook #'hide-mode-line-reset t)
       (setq mode-line-format hide-mode-line--old-format)
+      (mapc 'face-remap-remove-relative hide-mode-line--cookies)
       (setq-local hide-mode-line--old-format nil)))
   (force-mode-line-update))
 


### PR DESCRIPTION
Hi
This PR adds `hide-mode-line-face` to change the face of the `mode-line` while is hidden.
Now by default `hide-mode-line-format` is set to `""` and `hide-mode-line-face` has `(:box nil :foreground default-foreground :background default-background :height 0.1)`
It also adds `(redraw-display)` only when `hide-mode-line-format` is `nil`.

